### PR TITLE
Reduce binary size with ldflags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build: test
 
 release: test
 	@echo "== Release build =="
-	CGO_ENABLED=0 GOOS=$(TARGET) GOARCH=$(ARCH) go build -o $(BINARY_NAME)-$(TARGET)-$(ARCH)$(EXT) -v cmd/main.go
+	CGO_ENABLED=0 GOOS=$(TARGET) GOARCH=$(ARCH) go build -ldflags="-s -w" -o $(BINARY_NAME)-$(TARGET)-$(ARCH)$(EXT) -v cmd/main.go
 
 clean:
 	@echo "== Cleaning =="


### PR DESCRIPTION
The binary is currently 15mb, with this change it shrinks to 10mb. From the first recommendation here:
https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/

I did not include binary stripping since 33% reduction is a nice start, and I don't know how the 2nd recommendation (or the 1st for that matter) actually works. But at least the 1st can be done directly in `go build` 😂 