### PR TITLE
Bump Go version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ env:
 matrix:
   include:
   - os: linux 
-    go: 1.11.x
+    go: 1.13.x
     env:
     - TARGET=darwin
     - ARCH=amd64
   - os: linux
-    go: 1.11.x
+    go: 1.13.x
     env:
     - TARGET=linux
     - ARCH=amd64
   - os: linux
-    go: 1.11.x
+    go: 1.13.x
     env:
     - TARGET=windows
     - ARCH=amd64

--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816 // indirect
 	golang.org/x/text v0.3.0 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Latest release is too old so lets bump Go and dependencies.