### PR TITLE
adding functionality to parse json in multivalue secrets

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -106,7 +107,17 @@ func (m *Manager) Populate() error {
 		}
 
 		if found {
-			env[name] = secret
+			secretMap := make(map[string]string)
+			err = json.Unmarshal([]byte(secret), &secretMap)
+			// if the json Unmarshal errors that means the secret is not a json and we set the original env variable to the secret
+			if err != nil {
+				env[name] = secret
+			} else {
+				// if the secret is a json we want to set the key-value pairs within the json to the env variables
+				for keySecret, valueSecret := range secretMap {
+					env[keySecret] = valueSecret
+				}
+			}
 		}
 	}
 

--- a/environment_test.go
+++ b/environment_test.go
@@ -18,9 +18,8 @@ func TestMain(t *testing.T) {
 	tests := []struct {
 		description string
 		envKey      string
-		secretKey   string
 		envValue    string
-		secretValue string
+		secretMap   map[string]string
 		expect      string
 		json        bool
 		callsSM     bool
@@ -83,12 +82,14 @@ func TestMain(t *testing.T) {
 			envKey:      "TEST",
 			envValue:    "sm://<secret-path>",
 			expect:      "sm://<secret-path>",
-			secretKey:   "password",
-			secretValue: "secret",
-			json:        true,
-			callsSM:     true,
+			secretMap: map[string]string{
+				"user":     "test",
+				"password": "secret",
+			},
+			json:    true,
+			callsSM: true,
 			smOutput: &secretsmanager.GetSecretValueOutput{
-				SecretString: aws.String("{\"password\": \"secret\"}"),
+				SecretString: aws.String("{\"user\": \"test\",\"password\": \"secret\"}"),
 			},
 		},
 	}
@@ -136,8 +137,10 @@ func TestMain(t *testing.T) {
 				if got, want := os.Getenv(tc.envKey), tc.expect; got != want {
 					t.Errorf("\ngot: %s\nwanted: %s", got, want)
 				}
-				if got, want := os.Getenv(tc.secretKey), tc.secretValue; got != want {
-					t.Errorf("\ngot: %s\nwanted: %s", got, want)
+				for secretKey, secretValue := range tc.secretMap {
+					if got, want := os.Getenv(secretKey), secretValue; got != want {
+						t.Errorf("\ngot: %s\nwanted: %s", got, want)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
We have a use case where we store all of our service's secrets within one secrets manager secret as a single multi-value secret (this saves costs, and also limits api requests to secrets manager).  We have added functionality to parse json and set environment variables based on the parsed json.  The original functionality is still the same as long as the secret returned from the secrets manager isn't a json.